### PR TITLE
Update Dockerfile to rely on Alpine Wheels index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM python:3.8.5-alpine3.12
 
 COPY requirements.txt /black/requirements.txt
 
-RUN /sbin/apk add --no-cache --virtual .deps gcc musl-dev \
- && /usr/local/bin/pip install --no-cache-dir --requirement /black/requirements.txt \
- && /sbin/apk del --no-cache .deps
+RUN /usr/local/bin/pip install --no-cache-dir --requirement /black/requirements.txt
 
 ENV PYTHONUNBUFFERED="1"
 
-ENTRYPOINT ["/usr/local/bin/blackd", "--bind-host", "0.0.0.0"]
+ENTRYPOINT ["/usr/local/bin/blackd"]
+CMD ["--bind-host", "0.0.0.0"]
 
-LABEL org.opencontainers.image.authors="William Jackson <william@subtlecoolness.com>" \
-      org.opencontainers.image.version="19.10b0"
+LABEL org.opencontainers.image.authors="William Jackson <william@subtlecoolness.com>"


### PR DESCRIPTION
Remove OS packages to find out which Python package dependencies fail to install.